### PR TITLE
Support for ConfigurationSetName

### DIFF
--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -44,6 +44,7 @@ func Send(
 	from *string,
 	to *[]string,
 	data *[]byte,
+	setName *string,
 ) {
 	var err error
 	req := &Request{
@@ -59,6 +60,7 @@ func Send(
 		destinations = append(destinations, &v)
 	}
 	_, err = sesAPI.SendRawEmail(&ses.SendRawEmailInput{
+		ConfigurationSetName: setName,
 		Source:       from,
 		Destinations: destinations,
 		RawMessage:   &ses.RawMessage{Data: *data},

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -61,8 +61,8 @@ func Send(
 	}
 	_, err = sesAPI.SendRawEmail(&ses.SendRawEmailInput{
 		ConfigurationSetName: setName,
-		Source:       from,
-		Destinations: destinations,
-		RawMessage:   &ses.RawMessage{Data: *data},
+		Source:               from,
+		Destinations:         destinations,
+		RawMessage:           &ses.RawMessage{Data: *data},
 	})
 }

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -32,6 +32,7 @@ func sendHelper(
 	from *string,
 	to *[]string,
 	data *[]byte,
+	setName *string,
 ) (email *ses.SendRawEmailInput, out []byte, err []byte) {
 	outReader, outWriter, _ := os.Pipe()
 	errReader, errWriter, _ := os.Pipe()
@@ -45,7 +46,7 @@ func sendHelper(
 	os.Stdout = outWriter
 	os.Stderr = errWriter
 	func() {
-		relay.Send(&mockSESAPI{}, origin, from, to, data)
+		relay.Send(&mockSESAPI{}, origin, from, to, data, setName)
 		outWriter.Close()
 		errWriter.Close()
 	}()
@@ -59,8 +60,9 @@ func TestSend(t *testing.T) {
 	from := "alice@example.org"
 	to := []string{"bob@example.org"}
 	data := []byte{'T', 'E', 'S', 'T'}
+	setName := ""
 	timeBefore := time.Now()
-	input, out, err := sendHelper(&origin, &from, &to, &data)
+	input, out, err := sendHelper(&origin, &from, &to, &data, &setName)
 	timeAfter := time.Now()
 	if *input.Source != from {
 		t.Errorf(
@@ -106,7 +108,7 @@ func TestSend(t *testing.T) {
 	origin = net.TCPAddr{IP: []byte{
 		0x20, 0x01, 0x48, 0x60, 0, 0, 0x20, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0x68,
 	}}
-	_, out, err = sendHelper(&origin, &from, &to, &data)
+	_, out, err = sendHelper(&origin, &from, &to, &data, &setName)
 	json.Unmarshal(out, &req)
 	if req.IP != "2001:4860:0:2001::68" {
 		t.Errorf(

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	host     = flag.String("h", "", "Server hostname")
 	certFile = flag.String("c", "", "TLS cert file")
 	keyFile  = flag.String("k", "", "TLS key file")
+	setName	 = flag.String("o", "", "ConfigurationSet name")
 	startTLS = flag.Bool("s", false, "Require TLS via STARTTLS extension")
 	onlyTLS  = flag.Bool("t", false, "Listen for incoming TLS connections only")
 	ips      = flag.String("i", "", "Allowed client IPs (comma-separated)")
@@ -32,7 +33,7 @@ var ipMap map[string]bool
 var bcryptHash []byte
 
 func handler(origin net.Addr, from string, to []string, data []byte) {
-	relay.Send(client, origin, &from, &to, &data)
+	relay.Send(client, origin, &from, &to, &data, setName)
 }
 
 func authHandler(

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var (
 	host     = flag.String("h", "", "Server hostname")
 	certFile = flag.String("c", "", "TLS cert file")
 	keyFile  = flag.String("k", "", "TLS key file")
-	setName	 = flag.String("o", "", "ConfigurationSet name")
+	setName	 = flag.String("r", "", "Amazon SES Configuration Set Name")
 	startTLS = flag.Bool("s", false, "Require TLS via STARTTLS extension")
 	onlyTLS  = flag.Bool("t", false, "Listen for incoming TLS connections only")
 	ips      = flag.String("i", "", "Allowed client IPs (comma-separated)")


### PR DESCRIPTION
This PR resolves #1.

It introduces the ability to pass in a value for ConfigurationSetName which would otherwise be a default value (empty/""). The field has also been added to tests already supported by the application.

Testing will be organized prior to removing the draft flag, but I would appreciate some feedback from @blueimp in regards to how receptive they are to merging this and what they would like to see included in this PR leading up to a merge.

Also, for general knowledge, this field is [natively supported by the API](https://docs.aws.amazon.com/ses/latest/APIReference/API_SendRawEmail.html).