### PR TITLE
Added Dockerfiles for arm (32-bit) and arm64 (64-bit) architectures

### DIFF
--- a/dockerfile/amd64/Dockerfile
+++ b/dockerfile/amd64/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:alpine as build
+
+RUN apk --no-cache add git
+
+WORKDIR /opt
+
+COPY . .
+
+# Disable CGO to build a statically compiled binary.
+# ldflags explanation (see `go tool link`):
+#   -s  disable symbol table
+#   -w  disable DWARF generation
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/aws-smtp-relay
+
+FROM scratch
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+COPY --from=build /bin/aws-smtp-relay /bin/
+
+USER 65534
+
+ENTRYPOINT ["aws-smtp-relay"]

--- a/dockerfile/arm/Dockerfile
+++ b/dockerfile/arm/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:alpine as build
+
+RUN apk --no-cache add git
+
+WORKDIR /opt
+
+COPY . .
+
+# Disable CGO to build a statically compiled binary.
+# ldflags explanation (see `go tool link`):
+#   -s  disable symbol table
+#   -w  disable DWARF generation
+# GOARCH=arm permits cross compilation of the binary for ARM (32-bit)
+RUN CGO_ENABLED=0 GOARCH=arm go build -ldflags="-s -w" -o /bin/aws-smtp-relay
+
+FROM scratch
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+COPY --from=build /bin/aws-smtp-relay /bin/
+
+USER 65534
+
+ENTRYPOINT ["aws-smtp-relay"]

--- a/dockerfile/arm64/Dockerfile
+++ b/dockerfile/arm64/Dockerfile
@@ -1,15 +1,24 @@
 FROM golang:alpine as build
+
 RUN apk --no-cache add git
+
 WORKDIR /opt
+
 COPY . .
+
 # Disable CGO to build a statically compiled binary.
 # ldflags explanation (see `go tool link`):
 #   -s  disable symbol table
 #   -w  disable DWARF generation
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/aws-smtp-relay
+# GOARCH=arm64 permits cross compilation of the binary for ARM64 (64-bit)
+RUN CGO_ENABLED=0 GOARCH=arm64 go build -ldflags="-s -w" -o /bin/aws-smtp-relay
 
 FROM scratch
+
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 COPY --from=build /bin/aws-smtp-relay /bin/
+
 USER 65534
+
 ENTRYPOINT ["aws-smtp-relay"]


### PR DESCRIPTION
Allows for hub.docker.com's build infrastructure (which is x86_64 based) to properly compile images for arm and arm64 (i.e. Raspberry Pi type devices) architectures.

Similar to what I've done on my hub.docker.com account (https://hub.docker.com/r/andrewmiskell/aws-smtp-relay/tags), you can create a manifest file and you can publish a latest tag which will automatically pull in the appropriate architecture.

```
docker manifest create andrewmiskell/aws-smtp-relay:latest andrewmiskell/aws-smtp-relay:amd64 andrewmiskell/aws-smtp-relay:arm andrewmiskell/aws-smtp-relay:arm64

docker manifest annotate andrewmiskell/aws-smtp-relay:latest andrewmiskell/aws-smtp-relay:arm --os linux --arch arm

docker manifest annotate andrewmiskell/aws-smtp-relay:latest andrewmiskell/aws-smtp-relay:arm64 --os linux --arch arm64

docker manifest push andrewmiskell/aws-smtp-relay:latest
```

Personally, I just put them in a directory for dockerfile, but it may make more sense to you to call them Dockerfile (for amd64), Dockerfile.arm (for ARM32bit) and Dockerfile.arm64 (for ARM64bit).