### PR TITLE
Cross Account - sourceArn

### DIFF
--- a/internal/relay/ses/relay.go
+++ b/internal/relay/ses/relay.go
@@ -16,6 +16,9 @@ type Client struct {
 	setName         *string
 	allowFromRegExp *regexp.Regexp
 	denyToRegExp    *regexp.Regexp
+	sourceArn       *string
+	fromArn         *string
+	returnPathArn   *string
 }
 
 // Send uses the client SESAPI to send email data
@@ -40,6 +43,9 @@ func (c Client) Send(
 			Source:               &from,
 			Destinations:         allowedRecipients,
 			RawMessage:           &ses.RawMessage{Data: data},
+			SourceArn:            c.sourceArn,
+			FromArn:              c.fromArn,
+			ReturnPathArn:        c.returnPathArn,
 		})
 		relay.Log(origin, &from, allowedRecipients, err)
 		if err != nil {
@@ -54,11 +60,17 @@ func New(
 	configurationSetName *string,
 	allowFromRegExp *regexp.Regexp,
 	denyToRegExp *regexp.Regexp,
+	sourceArn *string,
+	fromArn *string,
+	returnPathArn *string,
 ) Client {
 	return Client{
 		sesAPI:          ses.New(session.Must(session.NewSession())),
 		setName:         configurationSetName,
 		allowFromRegExp: allowFromRegExp,
 		denyToRegExp:    denyToRegExp,
+		sourceArn:       sourceArn,
+		fromArn:         fromArn,
+		returnPathArn:   returnPathArn,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -29,9 +29,9 @@ var (
 	user      = flag.String("u", "", "Authentication username")
 	allowFrom = flag.String("l", "", "Allowed sender emails regular expression")
 	denyTo    = flag.String("d", "", "Denied recipient emails regular expression")
-	sourceArn = flag.String("sourcearn", "", "The ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the Source parameter of SendRawEmail.")
-	fromArn   = flag.String("fromarn", "", "The ARN of the identity that is associated with the sending authorization policy that permits you to specify a particular 'From' address in the header of the raw email.")
-	rPathArn  = flag.String("returnpatharn", "", "The ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the ReturnPath parameter of SendRawEmail.")
+	sourceArn = flag.String("f", "", "The SourceARN (when using with cross accounts) ")
+	fromArn   = flag.String("o", "", "The FromARN (when using with cross accounts)")
+	rPathArn  = flag.String("p", "", "The ReturnPathARN (when using with cross accounts)")
 )
 
 var ipMap map[string]bool

--- a/main.go
+++ b/main.go
@@ -29,6 +29,9 @@ var (
 	user      = flag.String("u", "", "Authentication username")
 	allowFrom = flag.String("l", "", "Allowed sender emails regular expression")
 	denyTo    = flag.String("d", "", "Denied recipient emails regular expression")
+	sourceArn = flag.String("sourcearn", "", "The ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the Source parameter of SendRawEmail.")
+	fromArn   = flag.String("fromarn", "", "The ARN of the identity that is associated with the sending authorization policy that permits you to specify a particular 'From' address in the header of the raw email.")
+	rPathArn  = flag.String("returnpatharn", "", "The ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the ReturnPath parameter of SendRawEmail.")
 )
 
 var ipMap map[string]bool
@@ -83,7 +86,7 @@ func configure() error {
 	case "pinpoint":
 		relayClient = pinpointrelay.New(setName, allowFromRegExp, denyToRegExp)
 	case "ses":
-		relayClient = sesrelay.New(setName, allowFromRegExp, denyToRegExp)
+		relayClient = sesrelay.New(setName, allowFromRegExp, denyToRegExp, sourceArn, fromArn, rPathArn)
 	default:
 		return errors.New("Invalid relay API: " + *relayAPI)
 	}

--- a/main.go
+++ b/main.go
@@ -82,6 +82,22 @@ func configure() error {
 			return errors.New("Denied recipient emails: " + err.Error())
 		}
 	}
+	if *sourceArn != "" {
+		if *fromArn == "" {
+			fromArn = sourceArn
+		}
+		if *rPathArn == "" {
+			rPathArn = sourceArn
+		}
+	} else {
+		sourceArn = nil
+	}
+	if *fromArn == "" {
+		fromArn = nil
+	}
+	if *rPathArn == "" {
+		rPathArn = nil
+	}
 	switch *relayAPI {
 	case "pinpoint":
 		relayClient = pinpointrelay.New(setName, allowFromRegExp, denyToRegExp)


### PR DESCRIPTION
Beginner with golang, I try to fixes #16 by implementing `SourceArn`, `FromArn` and `ReturnPathArn`

About adding some initializations in the `configure` function in main.go (e58ac12576e80cb7db6e2f1e8ca9110069033ba9) , I did so because when you provide only SourceArn without FromArn and ReturnPathArn, it seems that it don't work like [the documentation says ](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html#:~:text=If%20you%20only%20specify%20the%20SourceArn%2C%20Amazon%20SES%20sets%20the%20%22From%22%20address%20and%20the%20%22Return%20Path%22%20addresses%20to%20the%20identity%20that%20you%20specified%20in%20SourceArn.)